### PR TITLE
base R function durch lubridate ersetzen

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -146,11 +146,9 @@ An welchen Wochentagen jeweils pro Monat am meisten Ehen geschlossen worden sind
 Ehedaten_Datum <- Ehedaten |> 
   mutate(Jahr = year(Datum),
          Monat = month(Datum, label = TRUE, abbr = FALSE),
-         Wochentag = weekdays(Datum)) |> 
+         Wochentag = wday(Datum, label = TRUE, abbr = FALSE)) |> 
   group_by(Monat, Wochentag) |> 
-  summarize(Anzahl = n()) |> 
-  mutate(Wochentag = factor(Wochentag,
-                            levels = c("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"), ordered = TRUE))
+  summarize(Anzahl = n())
   
  
 ```


### PR DESCRIPTION
Hi @hildy-mueller, ich habe ein paar Veränderungen gemacht. Diese habe ich auf einer neuen Branch gemacht, namens `dev` (das steht für development). Du arbeitest sonst auf der `main` Branch.

Diese Veränderungen schicke ich dir nun mittels eines Pull Requests.

**Was ich geändert habe:**

In meinem neuesten Commit habe ich Base R Funktionen durch lubridate-Funktionen ersetzt, um den Code zu vereinfachen und konsistenter zu gestalten:

1. **`weekdays()` durch `wday()` ersetzt**: Statt der Base R Funktion `weekdays()` verwendest du jetzt die lubridate-Funktion `wday()` mit den Argumenten `label = TRUE` und `abbr = FALSE`, um die Wochentage direkt als beschriftete Faktoren zu erhalten.

2. **Manuelle Faktor-Umwandlung entfernt**: Die nachträgliche `mutate()`-Anweisung, die `Wochentag` manuell in einen geordneten Faktor mit englischen Wochentagnamen umgewandelt hat, ist nicht mehr nötig. `wday()` liefert die Wochentage bereits in der richtigen Reihenfolge.

Die genauen Änderungen kannst du hier sehen: https://github.com/rstatszh-k011/projekt-JennySojka/pull/5/files

**Um die Änderungen in dein Projekt zu übernehmen:**

1. **Pull Request mergen**: Klicke weiter unten auf den grünen Button "Merge pull request" und bestätige mit "Confirm merge". Damit werden meine Änderungen in deine `main` Branch übernommen.

2. **Änderungen in RStudio holen**: Öffne dein Projekt in RStudio auf Posit Cloud. Im Git-Tab (oben rechts) klickst du auf den blauen Pfeil nach unten ("Pull"). Damit holst du die aktualisierten Dateien von GitHub in dein RStudio Projekt.

Danach hast du alle Änderungen lokal verfügbar und kannst weiterarbeiten.
